### PR TITLE
Conditional relatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Follows Unicode LDML date patterns (https://www.unicode.org/reports/tr35/tr35-da
 Datie uses tagged template literals to define formats, returning a reusable function that accepts a Date object or compatible string. Formatters are cached by string.
 
 ```js
-import datie from 'datie'
+import d from 'datie'
 
 const string = '2020-05-13T08:34:30.911Z'
 const date = new Date(string)
 
-datie`d/M-y hh:mm`(string) // '13/5-2020 08:34'
-datie`d/M-y hh:mm`(date)    // '13/5-2020 08:34'
+d`d/M-y hh:mm`(string) // '13/5-2020 08:34'
+d`d/M-y hh:mm`(date)    // '13/5-2020 08:34'
 ```
 
 ## Supported Specifiers
@@ -78,15 +78,18 @@ Comprehensive list of format specifiers, with descriptions and examples (using J
 
 Use `R` for relative time vs. current time (`new Date()`). Handles past (`ago`) and future (`in`), with pluralization and `<5s` as `a few seconds ago`/`in a few seconds`. Threshold for `now` is under 5 seconds.
 
+There is an optional 2nd parameter accepted if you want to provide a different reference point instead of Date.now().
+
 Examples (assuming current time is July 22, 2025, 12:00:00):
 
 ```js
-const pastDate = new Date('2025-07-22T11:55:00')  // 5 minutes ago
-const futureDate = new Date('2025-07-22T12:10:00') // 10 minutes future
+const reference = new Date('2025-07-22T11:55:00')
+const pastDate = reference.getTime() - 1000 * 60 * 5  // 5 minutes ago
+const futureDate = reference.getTime() + 1000 * 60 * 10 // 10 minutes future
 
-datie`R`(pastDate)    // '5 minutes ago'
-datie`R`(futureDate)  // 'in 10 minutes'
-datie`R`(new Date())  // 'now' (or 'a few seconds ago' if slight offset)
+d`R`(pastDate, reference)    // '5 minutes ago'
+d`R`(futureDate, reference)  // 'in 10 minutes'
+d`R`(new Date())             // 'now' (or 'a few seconds ago' if slight offset)
 ```
 
 ## Relative Fallbacks
@@ -105,21 +108,21 @@ Examples (current: July 22, 2025, 12:00:00):
 const recentPast = new Date('2025-07-22T11:00:00')  // 1 hour ago
 const oldPast = new Date('2025-07-20T12:00:00')     // >1 day ago
 
-datie`R1D yyyy-MM-dd HH:mm`(recentPast)  // '1 hour ago'
-datie`R1D yyyy-MM-dd HH:mm`(oldPast)     // '2025-07-20 12:00'
+d`R1D yyyy-MM-dd HH:mm`(recentPast)  // '1 hour ago'
+d`R1D yyyy-MM-dd HH:mm`(oldPast)     // '2025-07-20 12:00'
 
 // Future fallback
 const nearFuture = new Date('2025-07-22T15:00:00')  // 3 hours future
 const farFuture = new Date('2025-08-22T12:00:00')   // >15 days future
 
-datie`yyyy-MM-dd HH:mm R3H`(nearFuture)  // 'in 3 hours'
-datie`yyyy-MM-dd HH:mm R3H`(farFuture)   // '2025-08-22 12:00'
+d`yyyy-MM-dd HH:mm R3H`(nearFuture)  // 'in 3 hours'
+d`yyyy-MM-dd HH:mm R3H`(farFuture)   // '2025-08-22 12:00'
 
 // Other specs
-datie`yyyy-MM-dd R15D`(farFuture)        // '2025-08-22' (31 days >15D)
-datie`yyyy-MM-dd R6M`(new Date('2025-12-22'))  // 'in 5 months'
-datie`yyyy-MM-dd R1Y`(new Date('2026-07-22'))  // 'in 1 year'
-datie`yyyy-MM-dd R1Y`(new Date('2027-01-01'))  // '2027-01-01' (>1Y)
+d`yyyy-MM-dd R15D`(farFuture)        // '2025-08-22' (31 days >15D)
+d`yyyy-MM-dd R6M`(new Date('2025-12-22'))  // 'in 5 months'
+d`yyyy-MM-dd R1Y`(new Date('2026-07-22'))  // 'in 1 year'
+d`yyyy-MM-dd R1Y`(new Date('2027-01-01'))  // '2027-01-01' (>1Y)
 ```
 
 ## Localization
@@ -127,7 +130,7 @@ datie`yyyy-MM-dd R1Y`(new Date('2027-01-01'))  // '2027-01-01' (>1Y)
 Override names for days, months, seasons (relative time fixed in English):
 
 ```js
-datie.names = {
+d.names = {
   days: ['Domingo', 'Lunes', /* Spanish days */],
   months: ['Enero', 'Febrero', /* Spanish months */],
   seasons: ['Primavera', 'Verano', 'Otoño', 'Invierno'],

--- a/README.md
+++ b/README.md
@@ -1,123 +1,145 @@
 # 🗓 Datie
 
-Small template string based date formatter for the browser and Node.js. It supports custom specifiers and relative time calculations without external libraries.
+Small template string based date formatter for the browser and Node.js. It supports custom specifiers and relative time calculations without external libraries. Datie is lightweight (~1KB minified) and caches formatters for performance.
 
-### LDML
+### LDML Compliance
 
-Follows unicode LDML date patterns (https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table) with 2 additional inclusions:
-
-- `o` suffix to enable eg. `1st, 2nd` etc
-- `R` relative timing, eg: `1 minute ago, 2 days ago` etc
+Follows Unicode LDML date patterns (https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table) with additions:
+- `o`: Ordinal suffix (e.g., `1st`, `2nd`) for numbers like day or month.
+- `R`: Relative time (e.g., `1 minute ago`, `in 2 days`).
+- `S`: Season number (1-4); `SS`: Padded; `SSS`: Name (e.g., `Summer`).
 
 # Usage
 
-Datie takes the format as a tagged template function and then returns a function which accepts the date or a `new Date` compatible string. Formatters are cached by string for reuse.
+Datie uses tagged template literals to define formats, returning a reusable function that accepts a Date object or compatible string. Formatters are cached by string.
 
 ```js
 import datie from 'datie'
 
-const string = "2020-05-13T08:34:30.911Z"
+const string = '2020-05-13T08:34:30.911Z'
 const date = new Date(string)
 
-datie`d/M-y hh:mm`(string) // 13/5-2020 08:34
-
-// or
-
-datie`d/M-y hh:mm`(date) // 13/5-2020 08:34
+datie`d/M-y hh:mm`(string) // '13/5-2020 08:34'
+datie`d/M-y hh:mm`(date)    // '13/5-2020 08:34'
 ```
 
 ## Supported Specifiers
 
-See the below comprehensive list of all format specifiers, with descriptions and examples (using date: July 19, 2025, Saturday, 12:34:56):
+Comprehensive list of format specifiers, with descriptions and examples (using July 19, 2025, Saturday, 12:34:56):
 
 - **Year**:
-  - `y`: Full year (e.g., 2025) → '2025'
-  - `yy`: Two-digit year (e.g., 25) → '25'
-  - `yyyy`: Full year (same as `y`) → '2025'
+  - `y` / `yyyy`: Full year → '2025'
+  - `yy`: Two-digit year → '25'
 
 - **Month**:
   - `M`: Month number (1-12) → '7'
   - `MM`: Padded month (01-12) → '07'
-  - `MMM`: Abbreviated month name → 'Jul'
-  - `MMMM`: Full month name → 'July'
-  - `MMMMM`: Narrow month name (first letter) → 'J'
+  - `MMM`: Abbreviated month → 'Jul'
+  - `MMMM`: Full month → 'July'
+  - `MMMMM`: Narrow month (first letter) → 'J'
 
 - **Day**:
   - `d`: Day of month (1-31) → '19'
   - `dd`: Padded day (01-31) → '19'
 
 - **Weekday**:
-  - `e`: Weekday number (0=Sunday to 6=Saturday) → '6'
-  - `ee`: Padded weekday number (00-06) → '06'
-  - `E`: Abbreviated weekday (same as `EE`/`EEE`) → 'Sat'
-  - `EE`: Abbreviated weekday → 'Sat'
-  - `EEE`: Abbreviated weekday → 'Sat'
-  - `EEEE`: Full weekday name → 'Saturday'
-  - `EEEEE`: Narrow weekday (first two letters, or adjusted) → 'Sa'
-  - `EEEEEE`: Shortest weekday (first letter) → 'S'
+  - `e`: Weekday number (0=Sun-6=Sat) → '6'
+  - `ee`: Padded weekday number → '06'
+  - `E` / `EE` / `EEE`: Abbreviated weekday → 'Sat'
+  - `EEEE`: Full weekday → 'Saturday'
+  - `EEEEE`: Narrow weekday → 'Sa'
+  - `EEEEEE`: Shortest weekday → 'S'
 
-- **Hour** (24-hour format; `h`/`hh` alias to `H`/`HH` for simplicity, no AM/PM support):
-  - `H`: Hour (0-23) → '12'
-  - `HH`: Padded hour (00-23) → '12'
-  - `h`: Hour (same as `H`) → '12'
-  - `hh`: Padded hour (same as `HH`) → '12'
+- **Hour** (24-hour; `h`/`hh` aliases `H`/`HH`; no AM/PM):
+  - `H` / `h`: Hour (0-23) → '12'
+  - `HH` / `hh`: Padded hour → '12'
 
 - **Minute**:
   - `m`: Minute (0-59) → '34'
-  - `mm`: Padded minute (00-59) → '34'
+  - `mm`: Padded minute → '34'
 
 - **Second**:
   - `s`: Second (0-59) → '56'
-  - `ss`: Padded second (00-59) → '56'
+  - `ss`: Padded second → '56'
 
-- **Week** (ISO week number, starting Thursday-based for year alignment):
-  - `w`: Week of year (1-53) → '29' (for 2025-07-19)
-  - `ww`: Padded week (01-53) → '29'
+- **Week** (ISO week, Thursday-based):
+  - `w`: Week of year (1-53) → '29'
+  - `ww`: Padded week → '29'
 
 - **Quarter**:
-  - `Q`: Quarter number (1-4) → '3'
-  - `QQ`: Padded quarter (01-04) → '03'
-  - `QQQ`: Quarter with 'Q' prefix → 'Q3'
-  - `QQQQ`: Full quarter with ordinal → '3rd quarter'
+  - `Q`: Quarter (1-4) → '3'
+  - `QQ`: Padded quarter → '03'
+  - `QQQ`: Prefixed quarter → 'Q3'
+  - `QQQQ`: Full with ordinal → '3rd quarter'
+
+- **Season**:
+  - `S`: Season (1=Spring-4=Winter) → '3'
+  - `SS`: Padded season → '03'
+  - `SSS`: Season name → 'Summer'
 
 - **Ordinal Suffix**:
-  - `o`: Adds ordinal suffix ('st', 'nd', 'rd', 'th') to the previous numeric value (e.g., in 'do' or 'Mo') → Use with day/month: 'do' → '19th'
+  - `o`: Suffix for prior number (e.g., `do` → '19th', `Qo` → '3rd')
 
 ## Relative Time Formatting
 
-Integrate relative time with the `R` specifier or use the dedicated method (`datie.relative`). It will calculate time differences with pluralization, handling past/future, and a `now` threshold (`< 5` seconds).
+Use `R` for relative time vs. current time (`new Date()`). Handles past (`ago`) and future (`in`), with pluralization and `<5s` as `a few seconds ago`/`in a few seconds`. Threshold for `now` is under 5 seconds.
 
-Assuming date is within `10` number
-
-- `a few seconds ago`
-- `10 seconds ago`
-- `10 minutes ago`
-- `10 hours ago`
-- `10 days ago`
-- `10 months ago`
-- `10 years ago`
-
-**Using Specifier**
-
-Always relative to current time (`new Date()`).
+Examples (assuming current time is July 22, 2025, 12:00:00):
 
 ```js
-datie`R`(date)
+const pastDate = new Date('2025-07-22T11:55:00')  // 5 minutes ago
+const futureDate = new Date('2025-07-22T12:10:00') // 10 minutes future
+
+datie`R`(pastDate)    // '5 minutes ago'
+datie`R`(futureDate)  // 'in 10 minutes'
+datie`R`(new Date())  // 'now' (or 'a few seconds ago' if slight offset)
 ```
 
-**Using Method**
+## Relative Fallbacks
 
-Allows custom reference date to be passed as 2nd parameter
+Combine relative time with a fallback format using thresholds. If the date is within the spec (past or future), show relative; else, use fallback.
+
+- **Syntax**:
+  - Past: `R<spec> <fallback>` (e.g., `R1D yyyy-MM-dd`) – Relative if past and within spec.
+  - Future: `<fallback> R<spec>` (e.g., `yyyy-MM-dd R1Y`) – Relative if future and within spec.
+- **Spec**: `<number>[unit]`; units: `m` (minutes, default), `H` (hours), `D` (days), `M` (months), `Y` (years). No spec = always relative (threshold Infinity).
+
+Examples (current: July 22, 2025, 12:00:00):
 
 ```js
-datie.reference(date, new Date())
+// Past fallback
+const recentPast = new Date('2025-07-22T11:00:00')  // 1 hour ago
+const oldPast = new Date('2025-07-20T12:00:00')     // >1 day ago
+
+datie`R1D yyyy-MM-dd HH:mm`(recentPast)  // '1 hour ago'
+datie`R1D yyyy-MM-dd HH:mm`(oldPast)     // '2025-07-20 12:00'
+
+// Future fallback
+const nearFuture = new Date('2025-07-22T15:00:00')  // 3 hours future
+const farFuture = new Date('2025-08-22T12:00:00')   // >15 days future
+
+datie`yyyy-MM-dd HH:mm R3H`(nearFuture)  // 'in 3 hours'
+datie`yyyy-MM-dd HH:mm R3H`(farFuture)   // '2025-08-22 12:00'
+
+// Other specs
+datie`yyyy-MM-dd R15D`(farFuture)        // '2025-08-22' (31 days >15D)
+datie`yyyy-MM-dd R6M`(new Date('2025-12-22'))  // 'in 5 months'
+datie`yyyy-MM-dd R1Y`(new Date('2026-07-22'))  // 'in 1 year'
+datie`yyyy-MM-dd R1Y`(new Date('2027-01-01'))  // '2027-01-01' (>1Y)
 ```
 
-**Example**
+## Localization
+
+Override names for days, months, seasons (relative time fixed in English):
 
 ```js
-datie`R`(new Date(Date.now() - 3600000)); // '1 hour ago' (assuming now is current)
-
-datie.relative('2025-07-18T12:00:00Z', new Date('2025-07-19T12:00:00Z')); // '1 day ago'
-datie.relative('2025-07-20T12:00:00Z', new Date('2025-07-19T12:00:00Z')); // 'in 1 day'
+datie.names = {
+  days: ['Domingo', 'Lunes', /* Spanish days */],
+  months: ['Enero', 'Febrero', /* Spanish months */],
+  seasons: ['Primavera', 'Verano', 'Otoño', 'Invierno'],
+  ordinals: ['o', 'o', 'o', 'o']  // Custom ordinals (e.g., Spanish)
+}
 ```
+
+> [!NOTE]
+> Localization doesn't alter LTR output or handle all global formats. Relative strings remain English.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # 🗓 Datie
 
-> Small template string based date formatter for the browser and Node.js.
+Small template string based date formatter for the browser and Node.js. It supports custom specifiers and relative time calculations without external libraries.
 
-Follows https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table with the inclusion of `o` suffix to enable eg. `1st, 2nd` etc.
+### LDML
 
-## Usage
+Follows unicode LDML date patterns (https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table) with 2 additional inclusions:
 
-Datie takes the format as a tagged template function and then returns a function which accepts the date or a `new Date` compatible string.
+- `o` suffix to enable eg. `1st, 2nd` etc
+- `R` relative timing, eg: `1 minute ago, 2 days ago` etc
+
+# Usage
+
+Datie takes the format as a tagged template function and then returns a function which accepts the date or a `new Date` compatible string. Formatters are cached by string for reuse.
 
 ```js
 import datie from 'datie'
@@ -19,4 +24,100 @@ datie`d/M-y hh:mm`(string) // 13/5-2020 08:34
 // or
 
 datie`d/M-y hh:mm`(date) // 13/5-2020 08:34
+```
+
+## Supported Specifiers
+
+See the below comprehensive list of all format specifiers, with descriptions and examples (using date: July 19, 2025, Saturday, 12:34:56):
+
+- **Year**:
+  - `y`: Full year (e.g., 2025) → '2025'
+  - `yy`: Two-digit year (e.g., 25) → '25'
+  - `yyyy`: Full year (same as `y`) → '2025'
+
+- **Month**:
+  - `M`: Month number (1-12) → '7'
+  - `MM`: Padded month (01-12) → '07'
+  - `MMM`: Abbreviated month name → 'Jul'
+  - `MMMM`: Full month name → 'July'
+  - `MMMMM`: Narrow month name (first letter) → 'J'
+
+- **Day**:
+  - `d`: Day of month (1-31) → '19'
+  - `dd`: Padded day (01-31) → '19'
+
+- **Weekday**:
+  - `e`: Weekday number (0=Sunday to 6=Saturday) → '6'
+  - `ee`: Padded weekday number (00-06) → '06'
+  - `E`: Abbreviated weekday (same as `EE`/`EEE`) → 'Sat'
+  - `EE`: Abbreviated weekday → 'Sat'
+  - `EEE`: Abbreviated weekday → 'Sat'
+  - `EEEE`: Full weekday name → 'Saturday'
+  - `EEEEE`: Narrow weekday (first two letters, or adjusted) → 'Sa'
+  - `EEEEEE`: Shortest weekday (first letter) → 'S'
+
+- **Hour** (24-hour format; `h`/`hh` alias to `H`/`HH` for simplicity, no AM/PM support):
+  - `H`: Hour (0-23) → '12'
+  - `HH`: Padded hour (00-23) → '12'
+  - `h`: Hour (same as `H`) → '12'
+  - `hh`: Padded hour (same as `HH`) → '12'
+
+- **Minute**:
+  - `m`: Minute (0-59) → '34'
+  - `mm`: Padded minute (00-59) → '34'
+
+- **Second**:
+  - `s`: Second (0-59) → '56'
+  - `ss`: Padded second (00-59) → '56'
+
+- **Week** (ISO week number, starting Thursday-based for year alignment):
+  - `w`: Week of year (1-53) → '29' (for 2025-07-19)
+  - `ww`: Padded week (01-53) → '29'
+
+- **Quarter**:
+  - `Q`: Quarter number (1-4) → '3'
+  - `QQ`: Padded quarter (01-04) → '03'
+  - `QQQ`: Quarter with 'Q' prefix → 'Q3'
+  - `QQQQ`: Full quarter with ordinal → '3rd quarter'
+
+- **Ordinal Suffix**:
+  - `o`: Adds ordinal suffix ('st', 'nd', 'rd', 'th') to the previous numeric value (e.g., in 'do' or 'Mo') → Use with day/month: 'do' → '19th'
+
+## Relative Time Formatting
+
+Integrate relative time with the `R` specifier or use the dedicated method (`datie.relative`). It will calculate time differences with pluralization, handling past/future, and a `now` threshold (`< 5` seconds).
+
+Assuming date is within `10` number
+
+- `a few seconds ago`
+- `10 seconds ago`
+- `10 minutes ago`
+- `10 hours ago`
+- `10 days ago`
+- `10 months ago`
+- `10 years ago`
+
+**Using Specifier**
+
+Always relative to current time (`new Date()`).
+
+```js
+datie`R`(date)
+```
+
+**Using Method**
+
+Allows custom reference date to be passed as 2nd parameter
+
+```js
+datie.reference(date, new Date())
+```
+
+**Example**
+
+```js
+datie`R`(new Date(Date.now() - 3600000)); // '1 hour ago' (assuming now is current)
+
+datie.relative('2025-07-18T12:00:00Z', new Date('2025-07-19T12:00:00Z')); // '1 day ago'
+datie.relative('2025-07-20T12:00:00Z', new Date('2025-07-19T12:00:00Z')); // 'in 1 day'
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Small template string based date formatter for the browser and Node.js. It suppo
 Follows Unicode LDML date patterns (https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table) with additions:
 - `o`: Ordinal suffix (e.g., `1st`, `2nd`) for numbers like day or month.
 - `R`: Relative time (e.g., `1 minute ago`, `in 2 days`).
-- `S`: Season number (1-4); `SS`: Padded; `SSS`: Name (e.g., `Summer`).
 
 # Usage
 
@@ -71,11 +70,6 @@ Comprehensive list of format specifiers, with descriptions and examples (using J
   - `QQ`: Padded quarter → '03'
   - `QQQ`: Prefixed quarter → 'Q3'
   - `QQQQ`: Full with ordinal → '3rd quarter'
-
-- **Season**:
-  - `S`: Season (1=Spring-4=Winter) → '3'
-  - `SS`: Padded season → '03'
-  - `SSS`: Season name → 'Summer'
 
 - **Ordinal Suffix**:
   - `o`: Suffix for prior number (e.g., `do` → '19th', `Qo` → '3rd')

--- a/datie.test.js
+++ b/datie.test.js
@@ -1,0 +1,140 @@
+import datie from  './index.js';
+
+let testCount = 0
+  , passedCount = 0;
+
+const { log } = console
+
+function title(name) {
+  log(`\n ⌗\x1b[1m ${name} \x1b[0m`)
+}
+
+function test(description) {
+
+  return (result) => {
+    testCount++;
+    log(`\x1b[1;92m » Format\x1b[0m \x1b[92m${description}\x1b[0m`);
+    log(`\x1b[90m » Result\x1b[1;0m ${result}\x1b[0m`)
+  }
+}
+
+
+const now = new Date()
+
+title('BASIC DATE FORMATTING');
+
+test('yyyy-MM-dd HH:mm')(datie`yyyy-MM-dd HH:mm`(now));
+test('MMM d, yyyy')(datie`MMM d, yyyy`(now));
+test('EEEE')(datie`EEEE`(now));
+test('yy-M-d h:m:s')(datie`yy-M-d h:m:s`(now));
+test('MMMM EE')(datie`MMMM EE`(now));
+test('ww')(datie`ww`(now));
+
+title('ORDINAL AND QUARTERS');
+
+test('do MMMM yyyy)')(datie`do MMMM yyyy`(now));
+test('Qo yyyy')(datie`Qo yyyy`(now));
+test('QQQQ')(datie`QQQQ`(now));
+test('QQQ')(datie`QQQ`(now));
+
+title('RELATIVES')
+test('R')(datie`R`(now - 5 * 60 * 1000));
+test('R')(datie`R`(now - 1 * 3600 * 1000));
+test('R')(datie`R`(now - 1 * 86400 * 1000));
+test('R')(datie`R`(now - 15 * 86400 * 1000));
+test('R')(datie`R`(now - 1 * 365 * 86400 * 1000));
+test('R')(datie`R`(now - 2 * 365 * 86400 * 1000));
+
+test('R')(datie`R`(now.getTime() + 10 * 60 * 1000));
+test('R')(datie`R`(now.getTime() + 1 * 3600 * 1000));
+test('R')(datie`R`(now.getTime() + 1 * 86400 * 1000));
+test('R')(datie`R`(now.getTime() + 15 * 86400 * 1000));
+test('R')(datie`R`(now.getTime() + 1 * 365 * 86400 * 1000));
+test('R')(datie`R`(now.getTime() + 2 * 365 * 86400 * 1000));
+
+title('PAST RELATIVE WITHIN 30 MINUTES');
+
+test('R30 yyyy-MM-dd HH:mm')(datie`R30 yyyy-MM-dd HH:mm`(now - 5 * 60 * 1000));
+test('R30 yyyy-MM-dd HH:mm')(datie`R30 yyyy-MM-dd HH:mm`(now - 15 * 60 * 1000));
+test('R30 yyyy-MM-dd HH:mm')(datie`R30 yyyy-MM-dd HH:mm`(now - 30 * 60 * 1000));
+
+title('PAST RELATIVE WITHIN 3 HOURS');
+
+test('R3H yyyy-MM-dd HH:mm')(datie`R3H yyyy-MM-dd HH:mm`(now - 1 * 3600 * 1000));
+test('R3H yyyy-MM-dd HH:mm')(datie`R3H yyyy-MM-dd HH:mm`(now - 2 * 3600 * 1000));
+test('R3H yyyy-MM-dd HH:mm')(datie`R3H yyyy-MM-dd HH:mm`(now - 3 * 3600 * 1000));
+
+title('PAST RELATIVE WITH 15 DAYS');
+
+test('R15D yyyy-MM-dd HH:mm')(datie`R15D yyyy-MM-dd HH:mm`(now - 1 * 86400 * 1000));
+test('R15D yyyy-MM-dd HH:mm')(datie`R15D yyyy-MM-dd HH:mm`(now - 10 * 86400 * 1000));
+test('R15D yyyy-MM-dd HH:mm')(datie`R15D yyyy-MM-dd HH:mm`(now - 15 * 86400 * 1000));
+
+title('PAST RELATIVE WITHIN 6 MONTHS');
+
+test('R6M yyyy-MM-dd')(datie`R6M yyyy-MM-dd`(now - 1 * 30 * 86400 * 1000));
+test('R6M yyyy-MM-dd')(datie`R6M yyyy-MM-dd`(now - 3 * 30 * 86400 * 1000));
+test('R6M yyyy-MM-dd')(datie`R6M yyyy-MM-dd`(now - 6 * 30 * 86400 * 1000));
+
+title('PAST RELATIVE WITH 1 YEAR');
+
+test('R1Y yyyy-MM-dd')(datie`R1Y yyyy-MM-dd`(now - 3 * 30 * 86400 * 1000));
+test('R1Y yyyy-MM-dd')(datie`R1Y yyyy-MM-dd`(now - 6 * 30 * 86400 * 1000));
+test('R1Y yyyy-MM-dd')(datie`R1Y yyyy-MM-dd`(now - 1 * 365 * 86400 * 1000));
+
+title('PAST RELATIVE WITH 2 YEARS');
+
+test('R2Y yyyy-MM-dd')(datie`R2Y yyyy-MM-dd`(now - 1 * 320 * 86400 * 1000));
+test('R2Y yyyy-MM-dd')(datie`R2Y yyyy-MM-dd`(now - 1 * 365 * 86400 * 1000));
+test('R2Y yyyy-MM-dd')(datie`R2Y yyyy-MM-dd`(now - 2 * 365 * 86400 * 1000));
+
+
+title('FUTURE RELATIVE OF 30 MINUTES');
+
+test('yyyy-MM-dd HH:mm R30')(datie`yyyy-MM-dd HH:mm R30`(now.getTime() + 10 * 60 * 1000));
+test('yyyy-MM-dd HH:mm R30')(datie`yyyy-MM-dd HH:mm R30`(now.getTime() + 15 * 60 * 1000));
+test('yyyy-MM-dd HH:mm R30')(datie`yyyy-MM-dd HH:mm R30`(now.getTime() + 30 * 60 * 1000));
+
+title('FUTURE RELATIVE OF 3 HOURS');
+
+test('yyyy-MM-dd HH:mm R3H')(datie`yyyy-MM-dd HH:mm R3H`(now.getTime() + 1 * 3600 * 1000));
+test('yyyy-MM-dd HH:mm R3H')(datie`yyyy-MM-dd HH:mm R3H`(now.getTime() + 2 * 3600 * 1000));
+test('yyyy-MM-dd HH:mm R3H')(datie`yyyy-MM-dd HH:mm R3H`(now.getTime() + 3 * 3600 * 1000));
+
+title('FUTURE RELATIVE OF 15 DAYS');
+
+test('yyyy-MM-dd HH:mm R15D')(datie`yyyy-MM-dd HH:mm R15D`(now.getTime() + 1 * 86400 * 1000));
+test('yyyy-MM-dd HH:mm R15D')(datie`yyyy-MM-dd HH:mm R15D`(now.getTime() + 2 * 86400 * 1000));
+test('yyyy-MM-dd HH:mm R15D')(datie`yyyy-MM-dd HH:mm R15D`(now.getTime() + 15 * 86400 * 1000));
+
+
+title('FUTURE RELATIVE OF 6 MONTHS');
+
+test('yyyy-MM-dd R6M')(datie`yyyy-MM-dd R6M`(now.getTime() + 1 * 30 * 86400 * 1000));
+test('yyyy-MM-dd R6M')(datie`yyyy-MM-dd R6M`(now.getTime() + 3 * 30 * 86400 * 1000));
+test('yyyy-MM-dd R6M')(datie`yyyy-MM-dd R6M`(now.getTime() + 6 * 30 * 86400 * 1000));
+
+title('FUTURE RELATIVE OF 1 YEAR');
+
+test('yyyy-MM-dd R1Y')(datie`yyyy-MM-dd R1Y`(now.getTime() + 1 * 30 * 86400 * 1000));
+test('yyyy-MM-dd R1Y')(datie`yyyy-MM-dd R1Y`(now.getTime() + 3 * 30 * 86400 * 1000));
+test('yyyy-MM-dd R1Y')(datie`yyyy-MM-dd R1Y`(now.getTime() + 1 * 365 * 86400 * 1000));
+
+title('FUTURE RELATIVE OF 2 YEARS');
+
+test('yyyy-MM-dd R2Y')(datie`yyyy-MM-dd R2Y`(now.getTime() + 1 * 320 * 86400 * 1000));
+test('yyyy-MM-dd R2Y')(datie`yyyy-MM-dd R2Y`(now.getTime() + 1 * 365 * 86400 * 1000));
+test('yyyy-MM-dd R2Y')(datie`yyyy-MM-dd R2Y`(now.getTime() + 2 * 365 * 86400 * 1000));
+
+
+title('SEASONS');
+
+const date = new Date(2025, 6, 22, 12, 0, 0)
+
+test('S')(datie`S`(date));
+test('SS')(datie`SS`(date));
+test('SSS')(datie`SSS`(new Date('2025-09-23T12:00:00+02:00')));
+test('SSS')(datie`SSS`(new Date('2025-12-22T12:00:00+01:00')));
+test('S')(datie`S`(new Date('2025-03-19T12:00:00+01:00')), '4');
+test('SSS')(datie`SSS`(new Date('2025-06-20T12:00:00+02:00')));
+

--- a/datie.test.js
+++ b/datie.test.js
@@ -126,15 +126,3 @@ test('yyyy-MM-dd R2Y')(datie`yyyy-MM-dd R2Y`(now.getTime() + 1 * 320 * 86400 * 1
 test('yyyy-MM-dd R2Y')(datie`yyyy-MM-dd R2Y`(now.getTime() + 1 * 365 * 86400 * 1000));
 test('yyyy-MM-dd R2Y')(datie`yyyy-MM-dd R2Y`(now.getTime() + 2 * 365 * 86400 * 1000));
 
-
-title('SEASONS');
-
-const date = new Date(2025, 6, 22, 12, 0, 0)
-
-test('S')(datie`S`(date));
-test('SS')(datie`SS`(date));
-test('SSS')(datie`SSS`(new Date('2025-09-23T12:00:00+02:00')));
-test('SSS')(datie`SSS`(new Date('2025-12-22T12:00:00+01:00')));
-test('S')(datie`S`(new Date('2025-03-19T12:00:00+01:00')), '4');
-test('SSS')(datie`SSS`(new Date('2025-06-20T12:00:00+02:00')));
-

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,135 @@
+interface TagLiteral extends ReadonlyArray<string> {
+  readonly raw: readonly string[];
+}
+
+type Interpolate = unknown[];
+
+const datie: {
+  /**
+   * Date format
+   *
+   * @example
+   * datie`yyyy-MM-dd HH:mm`(new Date()) // -> 2025-07-22 11:20
+   */
+  (format: TagLiteral, ...interpolate: Interpolate): (date: Date | string | number) => string;
+  /**
+   * Localisation Overrides
+   */
+  readonly names: {
+    /**
+     * Days of the week
+     *
+     * @default
+     * [
+     *  'Sunday',
+     *  'Monday',
+     *  'Tuesday',
+     *  'Wednesday',
+     *  'Thursday',
+     *  'Friday',
+     *  'Saturday'
+     * ]
+     */
+    days: [
+      Sunday: string,
+      Monday: string,
+      Tuesday: string,
+      Wednesday: string,
+      Thursday: string,
+      Friday: string,
+      Saturday: string
+    ];
+    /**
+     * Months of the year
+     *
+     * @default
+     * [
+     *  'January',
+     *  'February',
+     *  'March',
+     *  'April',
+     *  'May',
+     *  'June',
+     *  'July',
+     *  'August',
+     *  'September',
+     *  'October',
+     *  'November',
+     *  'December'
+     * ]
+     */
+    months: [
+      January: string,
+      February: string,
+      March: string,
+      April: string,
+      May: string,
+      June: string,
+      July: string,
+      August: string,
+      September: string,
+      October: string,
+      November: string,
+      December: string
+    ];
+    /**
+     * Time periods - Sorted by longest to shortest
+     *
+     * @default
+     * [
+     *  'year',
+     *  'month',
+     *  'week',
+     *  'day',
+     *  'hour',
+     *  'minute',
+     *  'second'
+     * ]
+     */
+    periods: [
+      year: string,
+      month: string,
+      week: string,
+      day: string,
+      hour: string,
+      minute: string,
+      second: string
+    ];
+    /**
+     * Ordinals - Smallest to largest
+     *
+     * @default
+     * [
+     *  'st',
+     *  'nd',
+     *  'rd',
+     *  'th'
+     * ]
+     */
+    ordinals: [
+      st: string,
+      nd: string,
+      rd: string,
+      th: string
+    ];
+    /**
+     * Seasons - Starting from Spring
+     *
+     * @default
+     * [
+     *  'Spring',
+     *  'Summer',
+     *  'Autumn',
+     *  'Winter'
+     * ]
+     */
+    seasons: [
+      Spring: string,
+      Summer: string,
+      Autumn: string,
+      Winter: string
+    ]
+  }
+}
+
+export default datie

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ const datie: {
    * Date format
    *
    * @example
-   * datie`yyyy-MM-dd HH:mm`(new Date()) // -> 2025-07-22 11:20
+   * d`yyyy-MM-dd HH:mm`(new Date()) // -> 2025-07-22 11:20
    */
   (format: TagLiteral, ...interpolate: Interpolate): (date: Date | string | number) => string;
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -111,23 +111,6 @@ const datie: {
       nd: string,
       rd: string,
       th: string
-    ];
-    /**
-     * Seasons - Starting from Spring
-     *
-     * @default
-     * [
-     *  'Spring',
-     *  'Summer',
-     *  'Autumn',
-     *  'Winter'
-     * ]
-     */
-    seasons: [
-      Spring: string,
-      Summer: string,
-      Autumn: string,
-      Winter: string
     ]
   }
 }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ export default datie
 const cache = new Map()
 const ordinals = ['', 'st', 'nd', 'rd']
 const ordinal = x => ordinals[x] || 'th'
+const sec = [31536000, 2592000, 604800, 86400, 3600, 60, 1]
 
 function format(X) {
   const weekMS = 1000 * 60 * 60 * 24 * 7
@@ -49,7 +50,8 @@ function format(X) {
     Q: x  => Math.floor(x.getMonth()/3) + 1,
     QQ: x  => pad(f.Q(x)),
     QQQ: x  => 'Q' + f.Q(x),
-    QQQQ: x  => f.Q(x) + ordinal(f.Q(x)) + ' quarter'
+    QQQQ: x  => f.Q(x) + ordinal(f.Q(x)) + ' quarter',
+    R: x => X.relative(x)
   }
 
   return f
@@ -57,8 +59,10 @@ function format(X) {
 
 datie.names = {
   days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+  uot: ['year', 'month', 'week', 'day', 'hour', 'minute', 'second']
 }
+
 datie.format = format(datie)
 
 function datie(xs) {
@@ -80,4 +84,24 @@ function datie(xs) {
 
   cache.set(xs, fn)
   return fn
+}
+
+datie.relative = function(date, reference = new Date()) {
+
+  let ss = Math.floor((reference - new Date(date)) / 1000);
+  const future = ss < 0;
+  ss = Math.abs(ss)
+
+  if (ss < 5)
+    return future ? 'in a few seconds' : 'a few seconds ago'
+
+  for (let i = 0, c, u; i < datie.names.uot.length; i++) {
+    c = Math.floor(ss / sec[i]);
+    if (c >= 1) {
+      u = datie.names.uot[i] + (c !== 1 ? 's' : '')
+      return future ? ('in ' + c + ' ' + u) : (c + ' ' + u + ' ago')
+    }
+  }
+
+  return 'now';
 }

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function format(X) {
 datie.names = {
   days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
   months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-  uot: ['year', 'month', 'week', 'day', 'hour', 'minute', 'second']
+  periods: ['year', 'month', 'week', 'day', 'hour', 'minute', 'second']
 }
 
 datie.format = format(datie)
@@ -95,10 +95,10 @@ datie.relative = function(date, reference = new Date()) {
   if (ss < 5)
     return future ? 'in a few seconds' : 'a few seconds ago'
 
-  for (let i = 0, c, u; i < datie.names.uot.length; i++) {
+  for (let i = 0, c, u; i < datie.names.periods.length; i++) {
     c = Math.floor(ss / sec[i]);
     if (c >= 1) {
-      u = datie.names.uot[i] + (c !== 1 ? 's' : '')
+      u = datie.names.periods[i] + (c !== 1 ? 's' : '')
       return future ? ('in ' + c + ' ' + u) : (c + ' ' + u + ' ago')
     }
   }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 export default datie
 
-const regexFuture = /^(.*)\s*R(\d+(?:[HDMY])?)?$/
-const regexPast = /^R(\d+(?:[HDMY])?)?\s*(.*)$/
+const regexFuture = /^(.*)\s*R(\d+(?:[MHDY])?)?$/
+const regexPast = /^R(\d+(?:[MHDY])?)?\s*(.*)$/
 const cache = new Map()
 const ordinals = ['', 'st', 'nd', 'rd', 'th']
 const ordinal = x => ordinals[x] || ordinals[4]
@@ -53,7 +53,7 @@ function format(X) {
     QQ: x => pad(f.Q(x)),
     QQQ: x => 'Q' + f.Q(x),
     QQQQ: x => f.Q(x) + ordinal(f.Q(x)) + ' quarter',
-    R: x => parseRelative(x)
+    R: (x, b) => parseRelative(x, b)
   }
 
   return f
@@ -69,81 +69,86 @@ datie.names = {
 
 datie.format = format(datie)
 
-function parseFormat(formatStr, X = datie) {
+function parseFormat(x, X = datie) {
   const fns = []
   let l = 0
-  for (let i = 0; i < formatStr.length; i++)
-    if (formatStr[i] !== formatStr[i + 1])
-      fns.push(X.format[formatStr.slice(l, i + 1)] || formatStr.slice(l, i + 1)), l = i + 1
+  for (let i = 0; i < x.length; i++)
+    if (x[i] !== x[i + 1])
+      fns.push(X.format[x.slice(l, i + 1)] || x.slice(l, i + 1)), l = i + 1
   return fns
 }
 
-function datie(xs) {
-  const formatStr = xs[0], key = formatStr
-  if (cache.has(key))
-    return cache.get(key)
-
-  let fn
-    , isPast = regexPast.test(key)
-    , isFuture = regexFuture.test(key)
-
-  if (!isPast && !isFuture) {
-    const fns = parseFormat(formatStr)
-    fn = function (x) {
-      x = new Date(x)
+function datie([x]) {
+  if (cache.has(x))
+    return cache.get(x)
+  
+  const R = x.indexOf('R')
+  
+  if (R === -1) {
+    const fns = parseFormat(x)
+    const fn = function (date) {
+      date instanceof Date || (date = new Date(date))
       let last
-      return fns.map(fn => last = typeof fn === 'function' ? fn(x, last) : fn).join('')
+      return fns.map(fn => last = typeof fn === 'function' ? fn(date, last) : fn).join('')
     }
-  } else {
-    const m = isPast ? formatStr.match(regexPast) : formatStr.match(regexFuture)
-    let spec
-      , unit
-      , fallback
-      , threshold = Infinity
-
-    isPast ? (spec = m[1], fallback = m[2]) : (spec = m[2], fallback = m[1])
-    if (spec) {
-      unit = spec[spec.length - 1]
-      const num = isNaN(unit) ? (unit = spec[spec.length - 1], +spec.slice(0, -1)) : (unit = 'm', +spec)
-      threshold = num * (
-        unit === 'm' ? sec[5] :
-        unit === 'H' ? sec[4] :
-        unit === 'D' ? sec[3] :
-        unit === 'W' ? sec[2] :
-        unit === 'M' ? sec[1] : sec[0]
-      ) * 1000
-    }
-    const fns = parseFormat(fallback || '')
-
-    fn = function(x) {
-      x = new Date(x)
-      const diff = new Date() - x, abs = Math.abs(diff)
-      // Apply relative formatting only if within threshold and correct direction
-      if (isPast && diff >= 0 && abs < threshold || isFuture && diff <= 0 && abs < threshold) {
-        return parseRelative(x)
-      }
-
-      let last
-      return fns.map(fn => last = typeof fn === 'function' ? fn(x, last) : fn).join('')
-    }
+    cache.set(x, fn)
+    return fn
   }
+  
+  const past = R === 0
+      , future = !past || x.length === 1
+      , m = past ? x.match(regexPast) : x.match(regexFuture)
+  
+  let threshold = Infinity
 
-  cache.set(key, fn)
+  const spec = m[past ? 1 : 2]
+      , fallback = m[past ? 2 : 1]
+    
+  if (spec) {
+    let unit = spec[spec.length - 1]
+    const num = isNaN(unit) 
+      ? (unit = spec[spec.length - 1], +spec.slice(0, -1)) 
+      : (unit = 'M', +spec)
+    
+    threshold = num * (
+      unit === 'M' ? sec[5] :
+      unit === 'H' ? sec[4] :
+      unit === 'D' ? sec[3] :
+      unit === 'W' ? sec[2] :
+      sec[0]
+    ) * 1000
+  }
+  
+  const fns = parseFormat(fallback || '')
+
+  const fn = function(date, b = new Date()) {
+    date instanceof Date || (date = new Date(date))
+    b instanceof Date || (b = new Date(b))
+    const diff = b - date
+        , abs = Math.abs(diff)
+    
+    if (past && diff >= 0 && abs <= threshold || future && diff <= 0 && abs <= threshold)
+      return parseRelative(date, b)
+
+    let last
+    return fns.map(fn => last = typeof fn === 'function' ? fn(date, last) : fn).join('')
+  }
+  
+  cache.set(x, fn)
   return fn
 }
 
-function parseRelative(date, reference = new Date()) {
-  let ss = Math.floor((reference - new Date(date)) / 1000)
+function parseRelative(date, reference = Date.now()) {
+  let ss = Math.floor((reference - new Date(date).getTime()) / 1000)
   const future = ss < 0
   ss = Math.abs(ss)
-
   if (ss < 5)
-    return future ? 'in a few seconds' : 'a few seconds ago'
+    return ss === 0 ? 'now' : ss < 0 ? 'in a few seconds' : 'a few seconds ago'
 
   for (let i = 0, c, u; i < datie.names.periods.length; i++) {
     if (i === 2 && ss > 3 * sec[2])
       continue
-    c = Math.floor(ss / sec[i])
+    c = ~~(ss / sec[i])
     if (c >= 1) {
       u = datie.names.periods[i] + (c !== 1 ? 's' : '')
       return future ? `in ${c} ${u}` : `${c} ${u} ago`

--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
 export default datie
 
+const regexFuture = /^(.*)\s*R(\d+(?:[HDMY])?)?$/
+const regexPast = /^R(\d+(?:[HDMY])?)?\s*(.*)$/
 const cache = new Map()
-const ordinals = ['', 'st', 'nd', 'rd']
-const ordinal = x => ordinals[x] || 'th'
-const sec = [31536000, 2592000, 604800, 86400, 3600, 60, 1]
+const ordinals = ['', 'st', 'nd', 'rd', 'th']
+const ordinal = x => ordinals[x] || ordinals[4]
+const sec = [31536000, 2592000, 86400, 3600, 60, 1]
 
 function format(X) {
-  const weekMS = 1000 * 60 * 60 * 24 * 7
+  const weekMS = 604800000
       , pad = x => x > 9 ? x : '0' + x
 
   const f = {
@@ -51,7 +53,15 @@ function format(X) {
     QQ: x  => pad(f.Q(x)),
     QQQ: x  => 'Q' + f.Q(x),
     QQQQ: x  => f.Q(x) + ordinal(f.Q(x)) + ' quarter',
-    R: x => X.relative(x)
+    S: x => {
+      const m = x.getMonth(), d = x.getDate()
+      return (m === 2 && d >= 20) || m === 3 || m === 4 || (m === 5 && d < 21) ? 1 :
+             (m === 5 && d >= 21) || m === 6 || m === 7 || (m === 8 && d < 23) ? 2 :
+             (m === 8 && d >= 23) || m === 9 || m === 10 || (m === 11 && d < 22) ? 3 : 4
+    },
+    SS: x => pad(f.S(x)),
+    SSS: x => X.names.seasons[f.S(x)-1],
+    R: x => parseRelative(x)
   }
 
   return f
@@ -60,48 +70,91 @@ function format(X) {
 datie.names = {
   days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
   months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-  periods: ['year', 'month', 'week', 'day', 'hour', 'minute', 'second']
+  periods: ['year', 'month', 'day', 'hour', 'minute', 'second'],
+  seasons: ['Spring', 'Summer', 'Autumn', 'Winter'],
+  get ordinals() { return ordinals },
+  set ordinals (o) { o.forEach((x, i) => ordinals.splice(i + 1, 1, x)) }
 }
 
 datie.format = format(datie)
 
-function datie(xs) {
-  if (cache.has(xs))
-    return cache.get(xs)
-
-  const f = xs[0]
-      , fns = []
-
+function parseFormat(formatStr, X = datie) {
+  const fns = []
   let l = 0
-  for (let i = 0; i < f.length; i++)
-    f[i] !== f[i + 1] && (fns.push(datie.format[f.slice(l, i + 1)] || f.slice(l, i + 1)), l = i + 1)
+  for (let i = 0; i < formatStr.length; i++)
+    if (formatStr[i] !== formatStr[i + 1])
+      fns.push(X.format[formatStr.slice(l, i + 1)] || formatStr.slice(l, i + 1)), l = i + 1
+  return fns
+}
 
-  const fn = function(x) {
-    x = new Date(x)
-    let last
-    return fns.map(fn => last = typeof fn === 'function' ? fn(x, last) : fn).join('')
+function datie(xs) {
+  const formatStr = xs[0], key = formatStr
+  if (cache.has(key))
+    return cache.get(key)
+
+  let fn
+    , isPast = regexPast.test(key)
+    , isFuture = regexFuture.test(key)
+
+  if (!isPast && !isFuture) {
+    const fns = parseFormat(formatStr)
+    fn = function (x) {
+      x = new Date(x)
+      let last
+      return fns.map(fn => last = typeof fn === 'function' ? fn(x, last) : fn).join('')
+    }
+  } else {
+    const m = isPast ? formatStr.match(regexPast) : formatStr.match(regexFuture)
+    let spec
+      , unit
+      , fallback
+      , threshold = Infinity
+
+    isPast ? (spec = m[1], fallback = m[2]) : (spec = m[2], fallback = m[1])
+    if (spec) {
+      unit = spec[spec.length - 1]
+      const num = isNaN(unit) ? (unit = spec[spec.length - 1], +spec.slice(0, -1)) : (unit = 'm', +spec)
+      threshold = num * (
+        unit === 'm' ? 60 :
+        unit === 'H' ? 3600 :
+        unit === 'D' ? 86400 :
+        unit === 'M' ? 2592000 : 31536000
+      ) * 1000
+    }
+    const fns = parseFormat(fallback || '')
+
+    fn = function(x) {
+      x = new Date(x)
+      const diff = new Date() - x, abs = Math.abs(diff)
+      // Apply relative formatting only if within threshold and correct direction
+      if (isPast && diff >= 0 && abs < threshold || isFuture && diff <= 0 && abs < threshold) {
+        return parseRelative(x)
+      }
+
+      let last
+      return fns.map(fn => last = typeof fn === 'function' ? fn(x, last) : fn).join('')
+    }
   }
 
-  cache.set(xs, fn)
+  cache.set(key, fn)
   return fn
 }
 
-datie.relative = function(date, reference = new Date()) {
-
-  let ss = Math.floor((reference - new Date(date)) / 1000);
-  const future = ss < 0;
+function parseRelative(date, reference = new Date()) {
+  let ss = Math.floor((reference - new Date(date)) / 1000)
+  const future = ss < 0
   ss = Math.abs(ss)
 
   if (ss < 5)
     return future ? 'in a few seconds' : 'a few seconds ago'
 
   for (let i = 0, c, u; i < datie.names.periods.length; i++) {
-    c = Math.floor(ss / sec[i]);
+    c = Math.floor(ss / sec[i])
     if (c >= 1) {
       u = datie.names.periods[i] + (c !== 1 ? 's' : '')
-      return future ? ('in ' + c + ' ' + u) : (c + ' ' + u + ' ago')
+      return future ? `in ${c} ${u}` : `${c} ${u} ago`
     }
   }
 
-  return 'now';
+  return 'now'
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "node ./datie.test.js"
+    "test": "sin test --ci --headless"
   },
   "engines": {
     "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -4,14 +4,16 @@
   "description": "Small template string based date formatter for the browser and Node.js.",
   "type": "module",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
-    "test": "echo please PR"
+    "test": "node ./datie.test.js"
   },
   "engines": {
     "node": ">=12"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "indes.d.ts"
   ],
   "author": "Rasmus Porsager <rasmus@porsager.com>",
   "license": "WTFPL",

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,141 @@
+import t from 'sin/test'
+
+import d from  '../index.js'
+
+const date = new Date('2025-08-24T09:42')
+const minute = 60 * 1000
+const hour = 60 * minute
+const day = 24 * hour
+const year = 365 * day
+
+t`Formatting`({
+  run: (x, t) => [x, d([t.name])(date)]
+},
+  t`Basic`(
+    t`yyyy-MM-dd HH:mm`('2025-08-24 09:42'),
+    t`MMM d, yyyy`('Aug 24, 2025'),
+    t`EEEE`('Sunday'),
+    t`yy-M-d h:m:s`('25-8-24 9:42:0'),
+    t`MMMM EE`('August Sun'),
+    t`ww`('34')
+  ),
+  
+  t`Ordinal And Quarters`(
+    t`do MMMM yyyy`('24th August 2025'),
+    t`Qo yyyy`('3rd 2025'),
+    t`QQQQ`('3rd quarter'),
+    t`QQQ`('Q3')
+  )
+)
+ 
+t`Relative`({
+  run: (x, y) => [y.name, d`R`(date.getTime() + x, date)]
+},
+  t`now`(0),
+  t`5 minutes ago`(-5 * minute),
+  t`1 hour ago`(-hour),
+  t`1 day ago`(-day),
+  t`2 weeks ago`(-15 * day),
+  t`1 year ago`(-year),
+  t`2 years ago`(-2 * year),
+  
+  t`in 10 minutes`(10 * minute),
+  t`in 1 hour`(hour),
+  t`in 1 day`(day),
+  t`in 2 weeks`(15 * day),
+  t`in 1 year`(year),
+  t`in 2 years`(2 * year)
+)
+
+t`Relative implicit now`({
+  run: (x, y) => [y.name, d`R`(Date.now() + x)]
+},
+  t`5 minutes ago`(-5 * minute),
+  t`1 hour ago`(-hour),
+  t`1 day ago`(-day),
+  t`2 weeks ago`(-15 * day),
+  t`1 year ago`(-1.2 * year),
+  
+  t`in 10 minutes`(10 * minute),
+  t`in 1 hour`(hour),
+  t`in 1 day`(day),
+  t`in 2 weeks`(15 * day),
+  t`in 1 year`(year),
+  t`in 1 year`(1.2 * year)
+)
+
+t`Relatives with fallbacks`({
+  run: (x, t) => [t.name, d(t.path.slice(-1))(date.getTime() + x, date)]
+}, 
+  t`R30 yyyy-MM-dd HH:mm`(
+    t`5 minutes ago`(-5 * minute),
+    t`15 minutes ago`(-15 * minute),
+    t`30 minutes ago`(-30 * minute)
+  ),
+  
+  t`R3H yyyy-MM-dd HH:mm`(
+    t`1 hour ago`(-hour),
+    t`2 hours ago`(-2 * hour),
+    t`3 hours ago`(-3 * hour)
+  ),
+  
+  t`R15D yyyy-MM-dd HH:mm`(
+    t`1 day ago`(-day),
+    t`1 week ago`(-10 * day),
+    t`2 weeks ago`(-15 * day)
+  ),
+  
+  t`R180D yyyy-MM-dd`(
+    t`1 month ago`(-30 * day),
+    t`3 months ago`(-90 * day),
+    t`6 months ago`(-180 * day)
+  ),
+  
+  t`R1Y yyyy-MM-dd`(
+    t`3 months ago`(-90 * day),
+    t`6 months ago`(-180 * day),
+    t`1 year ago`(-year)
+  ),
+  
+  t`R2Y yyyy-MM-dd`(
+    t`10 months ago`(-320 * day),
+    t`1 year ago`(-year),
+    t`2 years ago`(-2 * year)
+  ),
+  
+  t`yyyy-MM-dd HH:mm R30M`(
+    t`in 10 minutes`(10 * minute),
+    t`in 15 minutes`(15 * minute),
+    t`in 30 minutes`(30 * minute)
+  ),
+  
+  t`yyyy-MM-dd HH:mm R3H`(
+    t`in 1 hour`(hour),
+    t`in 2 hours`(2 * hour),
+    t`in 3 hours`(3 * hour)
+  ),
+  
+  t`yyyy-MM-dd HH:mm R15D`(
+    t`in 1 day`(day),
+    t`in 2 days`(2 * day),
+    t`in 2 weeks`(15 * day)
+  ),
+  
+  t`yyyy-MM-dd R180D`(
+    t`in 1 month`(30 * day),
+    t`in 3 months`(3 * 30 * day),
+    t`in 6 months`(6 * 30 * day)
+  ),
+  
+  t`yyyy-MM-dd R1Y`(
+    t`in 1 month`(30 * day),
+    t`in 3 months`(3 * 30 * day),
+    t`in 1 year`(year)
+  ),
+  
+  t`yyyy-MM-dd R2Y`(
+    t`in 10 months`(320 * day),
+    t`in 1 year`(1 * year),
+    t`in 2 years`(2 * year)
+  )
+)


### PR DESCRIPTION
- Added test reader
- Updated readme
- Support Conditional Relatives #10 with fallbacks in both directions. 
  - `R<0-9><H|D|M|Y>`
- Additional season based support to return current season 
  - `S`
  - `SS`
  - `SSS`
  